### PR TITLE
Update package.json to include the repository

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,10 @@
         "rxjs": "6.4.0"
       }
     },
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/cybercomet/ngx-nestable.git"
+    },
     "@angular-devkit/build-angular": {
       "version": "0.802.1",
       "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.802.1.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
       "email": "mgrubjesic89@gmail.com"
     }
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cybercomet/ngx-nestable.git"
+  },
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/nestable/package.json
+++ b/projects/nestable/package.json
@@ -19,6 +19,11 @@
       "email" : "mgrubjesic89@gmail.com"
     }
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cybercomet/ngx-nestable.git",
+    "directory": "projects/nestable"
+  },
   "keywords": [
     "angular",
     "nestable"


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your GitHub repositories, or wish to provide any other feedback, please comment on this PR.

Published NPM packages with repository information:
• ngx-nestable